### PR TITLE
为Qt Quick进行优化

### DIFF
--- a/FramelessHelper.qrc
+++ b/FramelessHelper.qrc
@@ -1,14 +1,21 @@
 <RCC>
     <qresource prefix="/">
-        <file>res/close-button1.png</file>
-        <file>res/close-button2.png</file>
-        <file>res/maximize-button1.png</file>
-        <file>res/maximize-button2.png</file>
-        <file>res/minimize-button1.png</file>
         <file>res/background.png</file>
         <file>qml/main.qml</file>
         <file>qml/CloseButton.qml</file>
         <file>qml/MaximizeButton.qml</file>
         <file>qml/MinimizeButton.qml</file>
+        <file>res/close-button1.svg</file>
+        <file>res/maximize-button1.svg</file>
+        <file>res/maximize-button2.svg</file>
+        <file>res/minimize-button1.svg</file>
+        <file>qml/CustomTitleBar.qml</file>
+        <file>qml/ThreeButtons.qml</file>
+        <file>qml/WindowBorder.qml</file>
+        <file>res/close-button1.png</file>
+        <file>res/close-button2.png</file>
+        <file>res/maximize-button1.png</file>
+        <file>res/maximize-button2.png</file>
+        <file>res/minimize-button1.png</file>
     </qresource>
 </RCC>

--- a/FramelessHelper/Kernels/NativeWindowHelper.cpp
+++ b/FramelessHelper/Kernels/NativeWindowHelper.cpp
@@ -13,6 +13,12 @@
 
 #include "NativeWindowFilter.h"
 
+#if defined(__GNUC__)
+//我电脑上的mingw报错，说没定义，那咋就给它定义一个
+//make mingw happy
+#define WM_DPICHANGED       0x02E0
+#endif
+
 // class NativeWindowHelper
 
 NativeWindowHelper::NativeWindowHelper(QWindow *window, NativeWindowTester *tester)

--- a/qml/CloseButton.qml
+++ b/qml/CloseButton.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Window 2.3
+import QtGraphicalEffects 1.0
 
 Button {
     id: control
@@ -7,19 +9,49 @@ Button {
     width: 45
     height: 26
 
-    ToolTip.visible: hovered && !down
-    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
-    ToolTip.text: qsTr("Close")
+    property string color: "black"
+    property string colorHoverd: "white"
+    property string colorPressed: "white"
+    property string colorInactive: "#969696"
+
+    property string bgcolorPressed: "#8c0a15"
+    property string bgcolorHoverd: "#e81123"
+    property string bgcolor: "transparent"
+
+    property bool changeColor: true
+    property bool active: changeColor ? Window.active : true
+
 
     contentItem: Item {
         Image {
+            id: img
+            width : 10
+            height: 10
+            visible: false
             anchors.centerIn: parent
-            source: control.down || control.hovered ? "qrc:/res/close-button2.png" : "qrc:/res/close-button1.png"
+            fillMode: Image.PreserveAspectFit
+            source: "qrc:/res/close-button1.svg"
+        }
+
+        ColorOverlay {
+            id: overLay
+            anchors.fill: img
+            source: img
+            cached: true
+            color: (control.down || control.hovered) ? control.colorHoverd:
+                       (control.active? control.color: control.colorInactive)
         }
     }
 
     background: Rectangle {
         visible: control.down || control.hovered
-        color: control.down ? "#8c0a15" : (control.hovered ? "#e81123" : "transparent")
+        color: control.down ? control.bgcolorPressed : (control.hovered ? control.bgcolorHoverd : control.bgcolor)
     }
+
+
+    ToolTip.visible: hovered && !down
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Close")
 }
+
+

--- a/qml/CustomTitleBar.qml
+++ b/qml/CustomTitleBar.qml
@@ -1,0 +1,12 @@
+import QtQuick 2.0
+
+Item {
+    id: titleBar
+    anchors {
+        top: parent.top
+        left: parent.left
+        right: parent.right
+    }
+
+    height: 28
+}

--- a/qml/MaximizeButton.qml
+++ b/qml/MaximizeButton.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Window 2.3
+import QtGraphicalEffects 1.0
 
 Button {
     id: control
@@ -7,21 +9,48 @@ Button {
     width: 45
     height: 26
 
-    ToolTip.visible: hovered && !down
-    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
-    ToolTip.text: qsTr("Maximize")
+    property string color: "black"
+    property string colorHoverd: "white"
+    property string colorPressed: "white"
+    property string colorInactive: "#969696"
 
-    property bool maximized: false
+    property string bgcolorPressed: "#80808080"
+    property string bgcolorHoverd: "#80c7c7c7"
+    property string bgcolor: "transparent"
+
+    property bool changeColor: true
+    property bool active: changeColor ? Window.active : true
+    property bool maximized: Window.Maximized === Window.visibility
 
     contentItem: Item {
         Image {
+            id: img
+            width : 10
+            height: 10
+            visible: false
             anchors.centerIn: parent
-            source: maximized ? "qrc:/res/maximize-button2.png" : "qrc:/res/maximize-button1.png"
+            fillMode: Image.PreserveAspectFit
+            source: maximized ? "qrc:/res/maximize-button2.svg" : "qrc:/res/maximize-button1.svg"
+        }
+
+        ColorOverlay {
+            id: overLay
+            anchors.fill: img
+            source: img
+            cached: true
+            color: (control.down || control.hovered) ? control.colorHoverd:
+                       (control.active? control.color: control.colorInactive)
+
         }
     }
 
     background: Rectangle {
         visible: control.down || control.hovered
-        color: control.down ? "#80808080" : (control.hovered ? "#80c7c7c7" : "transparent")
+        color: control.down ? control.bgcolorPressed : (control.hovered ? control.bgcolorHoverd : control.bgcolor)
     }
+
+    ToolTip.visible: hovered && !down
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Maximize")
 }
+

--- a/qml/MinimizeButton.qml
+++ b/qml/MinimizeButton.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
+import QtQuick.Window 2.3
+import QtGraphicalEffects 1.0
 
 Button {
     id: control
@@ -7,19 +9,46 @@ Button {
     width: 45
     height: 26
 
-    ToolTip.visible: hovered && !down
-    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
-    ToolTip.text: qsTr("Minimize")
+    property string color: "black"
+    property string colorHoverd: "white"
+    property string colorPressed: "white"
+    property string colorInactive: "#969696"
+
+    property string bgcolorPressed: "#80808080"
+    property string bgcolorHoverd: "#80c7c7c7"
+    property string bgcolor: "transparent"
+
+    property bool changeColor: true
+    property bool active: changeColor ? Window.active : true
 
     contentItem: Item {
         Image {
+            id: img
+            width : 10
+            height: 10
+            visible: false
             anchors.centerIn: parent
-            source: "qrc:/res/minimize-button1.png"
+            fillMode: Image.PreserveAspectFit
+            source: "qrc:/res/minimize-button1.svg"
+        }
+
+        ColorOverlay {
+            id: overLay
+            anchors.fill: img
+            source: img
+            cached: true
+            color: (control.down || control.hovered) ? control.colorHoverd:
+                       (control.active? control.color: control.colorInactive)
+
         }
     }
 
     background: Rectangle {
         visible: control.down || control.hovered
-        color: control.down ? "#80808080" : (control.hovered ? "#80c7c7c7" : "transparent")
+        color: control.down ? control.bgcolorPressed : (control.hovered ? control.bgcolorHoverd : control.bgcolor)
     }
+
+    ToolTip.visible: hovered && !down
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Minimize")
 }

--- a/qml/ThreeButtons.qml
+++ b/qml/ThreeButtons.qml
@@ -1,0 +1,45 @@
+import QtQuick 2.0
+import QtQuick.Window 2.3
+
+Row {
+    id: control
+
+    property var helper
+    property bool active: Window.active
+    property bool noWarning: false
+    property string color: "black"
+
+    anchors {
+        top: parent.top
+        right: parent.right
+        margins: 1
+    }
+
+    MinimizeButton {
+        color: control.color
+        onClicked: {helper.triggerMinimizeButtonAction()}
+    }
+
+    MaximizeButton {
+        color: control.color
+        onClicked: {helper.triggerMaximizeButtonAction()}
+    }
+
+    CloseButton {
+        color: control.color
+        onClicked: {helper.triggerCloseButtonAction()}
+    }
+
+    Component.onCompleted: {
+        if (!noWarning){
+            var arr = parent.children
+            if (control !== arr[arr.length-1]) {
+                console.log("Warning: ThreeButtons is not the last element!")
+                console.log("Note: You can disable this warning by setting noWarning to true")
+                console.log("Warning: ThreeButtons 不是最后的一个元素, 小心它可能会被别的东西（比如图片）遮住而无法操作")
+                console.log("Note: 可以将noWarning设为true来关掉这个警告")
+            }
+
+        }
+    }
+}

--- a/qml/WindowBorder.qml
+++ b/qml/WindowBorder.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.0
+import QtQuick.Window 2.3
+
+Rectangle {
+    id: control
+
+    property string foregroundColor: "#242424"
+    property string backgroundColor: "#969696"
+
+    property bool changeColor: true
+    property bool active: changeColor?Window.active: true
+
+    anchors.fill: parent
+
+    border.width: 1
+    color: "transparent"
+    border.color: active ? foregroundColor : backgroundColor
+
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.9
 import QtQuick.Window 2.2
 import QtShark.Window 1.0
+import QtQuick.Controls 2.5
 
 Window {
     id: window
@@ -27,78 +28,12 @@ Window {
         source: "qrc:/res/background.png"
     }
 
-    /*
-    Rectangle {
-        anchors {
-            fill: parent
-        }
-
-        color: "transparent"
-
-        border {
-            width: 1
-            color: "red"
-        }
-    }
-
-    Rectangle {
-        anchors {
-            fill: parent
-            margins: 4
-        }
-
-        color: "transparent"
-
-        border {
-            width: 1
-            color: "blue"
-        }
-    }
-    */
-
-    Item {
-        id: titleBar
-        anchors {
-            top: parent.top
-            left: parent.left
-            right: parent.right
-        }
-
-        height: 26
-    }
-
-    Row {
-        id: controls
-        anchors {
-            top: titleBar.top
-            right: titleBar.right
-        }
-
-        MinimizeButton {
-            onClicked: {
-                framelessHelper.triggerMinimizeButtonAction();
-            }
-        }
-        MaximizeButton {
-            maximized: Window.Maximized === window.visibility
-            onClicked: {
-                framelessHelper.triggerMaximizeButtonAction();
-            }
-        }
-        CloseButton {
-            onClicked: {
-                framelessHelper.triggerCloseButtonAction();
-            }
-        }
-    }
 
     Text {
-        anchors {
-            top: titleBar.bottom
-            left: parent.left
-            right: parent.right
-            bottom: parent.bottom
-        }
+        id: txt
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        anchors.verticalCenter: parent.verticalCenter
 
         text: "Qt Quick Inside"
         font {
@@ -107,8 +42,52 @@ Window {
         }
         color: "#fefefe"
 
-        verticalAlignment: Text.AlignVCenter
-        horizontalAlignment: Text.AlignHCenter
+    }
+
+    Row {
+        id: colorPicker
+        width: parent.width
+        anchors.top: txt.bottom
+        anchors.topMargin: 20
+        Slider {
+            id: sr
+            from: 0
+            to: 1
+            value: 0
+            width: (parent.width - 20)/3
+        }
+        Slider {
+            id: sg
+            from: 0
+            to: 1
+            value: 0
+            width: (parent.width - 20)/3
+
+        }
+        Slider {
+            id: sb
+            from: 0
+            to: 1
+            value: 0
+            width: (parent.width - 20)/3
+
+        }
+
+    }
+
+
+    CustomTitleBar {
+        id: titleBar
+    }
+
+    WindowBorder {
+        foregroundColor: Qt.rgba(sr.value,sg.value,sb.value,1)
+    }
+
+    ThreeButtons {
+        id: controls
+        helper: framelessHelper
+        color: Qt.rgba(sr.value,sg.value,sb.value,1)
     }
 
     Component.onCompleted: {

--- a/res/close-button1.svg
+++ b/res/close-button1.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="40" version="1.1" viewBox="0 0 10.583 10.583" xmlns="http://www.w3.org/2000/svg">
+ <title>closebtn</title>
+ <g transform="translate(0 -286.42)">
+  <path d="m0.23484 296.77 10.114-10.114m-10.114 0 10.114 10.114" fill="none" stroke="#FFFFFF" stroke-width="1px"/>
+ </g>
+</svg>

--- a/res/maximize-button1.svg
+++ b/res/maximize-button1.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="40" version="1.1" viewBox="0 0 10.583 10.583" xmlns="http://www.w3.org/2000/svg">
+ <title>max1</title>
+ <g transform="translate(0 -286.42)">
+  <rect x=".52586" y="286.94" width="9.5316" height="9.5316" fill="none" stroke="#FFFFFF" stroke-width="1.0517" style="paint-order:fill markers stroke"/>
+ </g>
+</svg>

--- a/res/maximize-button2.svg
+++ b/res/maximize-button2.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="40" version="1.1" viewBox="0 0 10.583 10.583" xmlns="http://www.w3.org/2000/svg">
+ <title>maxbtn2</title>
+ <g transform="translate(0 -286.42)">
+  <path d="m0.38644 289.14h7.4745v7.4745h-7.4745zm2.336-2.4e-4v-2.3358h7.4745v7.4745h-2.3358" fill="none" stroke="#FFFFFF" stroke-width=".77288" style="paint-order:fill markers stroke"/>
+ </g>
+</svg>

--- a/res/minimize-button1.svg
+++ b/res/minimize-button1.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="4" version="1.1" viewBox="0 0 10.583 1.0583" xmlns="http://www.w3.org/2000/svg">
+ <title>minbtn</title>
+ <g transform="translate(0 -290.99)" stroke="#000" stroke-width="1.0583">
+  <path d="m0 291.52h10.583" fill="none" stroke="#FFFFFF" stroke-width="1.0583"/>
+ </g>
+</svg>


### PR DESCRIPTION
- 自行绘制了几个矢量图，使得高DPI缩放时不会糊掉
- 导出最大化、最小化、关闭按钮的一些属性，方便进行自定义
- 把上述三个按钮打包在一起，方便使用
- 创建了程序的边框，使得看上去更像原生窗口
- 按钮的和边框可以在程序失去焦点时变灰（也可以设置成其它颜色）
- 将这些新特性用在main.qml里